### PR TITLE
BLD: add various shell scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 .DS_Store
+/tmp

--- a/download_data.sh
+++ b/download_data.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+DATA_DIR=./tmp/data/cifar10
+python models/research/slim/download_and_convert_data.py \
+    --dataset_name=cifar10 \
+    --dataset_dir=${DATA_DIR}
+
+# Now we can easily create a TF-Slim dataset descriptor...
+# https://github.com/tensorflow/models/tree/master/research/slim#creating-a-tf-slim-dataset-descriptor

--- a/verify-tf-slim.sh
+++ b/verify-tf-slim.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Tests if installation of tf.contrib.slim (via Tensorflow 1.0) is working
+echo 'Verifying Tensorflow Slim...'
+python -c "import tensorflow.contrib.slim as slim; eval = slim.evaluation.evaluate_once"
+echo 'Success.\n'
+
+# Tests if submodule of tensorflow/models/research/slim is present
+echo 'Verifying Tensorflow Slim image models library...'
+cd ./models/research/slim
+python -c "from nets import cifarnet; mynet = cifarnet.cifarnet"
+echo 'Success.\n'
+
+echo 'Tensorflow Slim installations present and working.'


### PR DESCRIPTION
`verify-tf-slim.sh` verifies the tensorflow isntallation (to make sure tf slim is installed), and verifies if the tf slim image models library is present (which should be included as a git submodule).

`download_data.sh` downloads the CIFAR-10 dataset and prepares it in some special TF-Slim format. The script can easily be modified to download any of [these datasets](https://github.com/tensorflow/models/tree/master/research/slim#preparing-the-datasets). Note that CIFAR-100 is not included, but it should be fairly straightforward to change by editing [this line](https://github.com/tensorflow/models/blob/b88da6eeae7fca17e299c8ee460d073a4aeec344/research/slim/datasets/download_and_convert_cifar10.py#L41) in our models submodule.