### PR TITLE
Add microbatches

### DIFF
--- a/inception_v3.py
+++ b/inception_v3.py
@@ -45,8 +45,8 @@ def conv2d_bn(x,
               padding='same',
               strides=(1, 1),
               renorm=False,
-              ghost_size=32,
-              num_ghosts=50,
+              microbatch_size=32,
+              num_microbatches=50,
               name=None):
     """Utility function to apply conv + BN.
 
@@ -58,8 +58,8 @@ def conv2d_bn(x,
         padding: padding mode in `Conv2D`.
         strides: strides in `Conv2D`.
         renorm: if True, apply batch renorm instead of batch norm.
-        ghost_size: number of examples in one ghost.
-        num_ghosts: number of ghosts in one minibatch.
+        microbatch_size: number of examples in one microbatch.
+        num_microbatches: number of microbatches in one minibatch.
         name: name of the ops; will become `name + '_conv'`
             for the convolution and `name + '_bn'` for the
             batch norm layer.
@@ -85,13 +85,13 @@ def conv2d_bn(x,
         name=conv_name)(x)
 
     if not renorm:
-        # Technically, ghost batch normalization calls for updating gradient's
-        # moments sequentially from ghost batch to ghost batch. However, the
+        # Technically, microbatch batch normalization calls for updating gradient's
+        # moments sequentially from microbatch batch to microbatch batch. However, the
         # Tensorflow implementation does _not_ do this, instead averaging over
         # the moments. This is exactly what we need. See
         # https://github.com/tensorflow/tensorflow/blob/c19e29306ce1777456b2dbb3a14f511edf7883a8/tensorflow/python/keras/layers/normalization.py#L581-L585
         x = layers.BatchNormalization(axis=bn_axis, scale=False,
-                                      virtual_batch_size=ghost_size,
+                                      virtual_batch_size=microbatch_size,
                                       name=bn_name)(x)
     else:
         # TODO(andrey) implement batch renorm with a tf.keras.layers interface
@@ -108,8 +108,8 @@ def InceptionV3(include_top=True,
                 pooling=None,
                 classes=1000,
                 renorm=False,
-                ghost_size=32,
-                num_ghosts=50,
+                microbatch_size=32,
+                num_microbatches=50,
                 **kwargs):
     """Instantiates the Inception v3 architecture.
 
@@ -147,8 +147,8 @@ def InceptionV3(include_top=True,
             into, only to be specified if `include_top` is True, and
             if no `weights` argument is specified.
         renorm: if True, apply batch renorm instead of batch norm.
-        ghost_size: number of examples in one ghost.
-        num_ghosts: number of ghosts in one minibatch.
+        microbatch_size: number of examples in one microbatch.
+        num_microbatches: number of microbatches in one minibatch.
 
     # Returns
         A Keras model instance.
@@ -190,40 +190,52 @@ def InceptionV3(include_top=True,
         channel_axis = 3
 
     x = conv2d_bn(img_input, 32, 3, 3, strides=(2, 2), padding='valid',
-                  renorm=renorm, ghost_size=ghost_size, num_ghosts=num_ghosts)
+                  renorm=renorm, microbatch_size=microbatch_size,
+                  num_microbatches=num_microbatches)
     x = conv2d_bn(x, 32, 3, 3, padding='valid',
-                  renorm=renorm, ghost_size=ghost_size, num_ghosts=num_ghosts)
+                  renorm=renorm, microbatch_size=microbatch_size,
+                  num_microbatches=num_microbatches)
     x = conv2d_bn(x, 64, 3, 3,
-                  renorm=renorm, ghost_size=ghost_size, num_ghosts=num_ghosts)
+                  renorm=renorm, microbatch_size=microbatch_size,
+                  num_microbatches=num_microbatches)
     x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)
 
     x = conv2d_bn(x, 80, 1, 1, padding='valid',
-                  renorm=renorm, ghost_size=ghost_size, num_ghosts=num_ghosts)
+                  renorm=renorm, microbatch_size=microbatch_size,
+                  num_microbatches=num_microbatches)
     x = conv2d_bn(x, 192, 3, 3, padding='valid',
-                  renorm=renorm, ghost_size=ghost_size, num_ghosts=num_ghosts)
+                  renorm=renorm, microbatch_size=microbatch_size,
+                  num_microbatches=num_microbatches)
     x = layers.MaxPooling2D((3, 3), strides=(2, 2))(x)
 
     # mixed 0: 35 x 35 x 256
     branch1x1 = conv2d_bn(x, 64, 1, 1, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
 
     branch5x5 = conv2d_bn(x, 48, 1, 1, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
     branch5x5 = conv2d_bn(branch5x5, 64, 5, 5, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
 
     branch3x3dbl = conv2d_bn(x, 64, 1, 1, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
     branch3x3dbl = conv2d_bn(branch3x3dbl, 96, 3, 3, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
     branch3x3dbl = conv2d_bn(branch3x3dbl, 96, 3, 3, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
 
     branch_pool = layers.AveragePooling2D((3, 3),
                                           strides=(1, 1),
                                           padding='same')(x)
     branch_pool = conv2d_bn(branch_pool, 32, 1, 1, renorm=renorm,
-                            ghost_size=ghost_size, num_ghosts=num_ghosts)
+                            microbatch_size=microbatch_size,
+                            num_microbatches=num_microbatches)
     x = layers.concatenate(
         [branch1x1, branch5x5, branch3x3dbl, branch_pool],
         axis=channel_axis,
@@ -231,25 +243,32 @@ def InceptionV3(include_top=True,
 
     # mixed 1: 35 x 35 x 288
     branch1x1 = conv2d_bn(x, 64, 1, 1, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
 
     branch5x5 = conv2d_bn(x, 48, 1, 1, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
     branch5x5 = conv2d_bn(branch5x5, 64, 5, 5, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
 
     branch3x3dbl = conv2d_bn(x, 64, 1, 1, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
     branch3x3dbl = conv2d_bn(branch3x3dbl, 96, 3, 3, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
     branch3x3dbl = conv2d_bn(branch3x3dbl, 96, 3, 3, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
 
     branch_pool = layers.AveragePooling2D((3, 3),
                                           strides=(1, 1),
                                           padding='same')(x)
     branch_pool = conv2d_bn(branch_pool, 64, 1, 1, renorm=renorm,
-                            ghost_size=ghost_size, num_ghosts=num_ghosts)
+                            microbatch_size=microbatch_size,
+                            num_microbatches=num_microbatches)
     x = layers.concatenate(
         [branch1x1, branch5x5, branch3x3dbl, branch_pool],
         axis=channel_axis,
@@ -257,25 +276,32 @@ def InceptionV3(include_top=True,
 
     # mixed 2: 35 x 35 x 288
     branch1x1 = conv2d_bn(x, 64, 1, 1, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
 
     branch5x5 = conv2d_bn(x, 48, 1, 1, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
     branch5x5 = conv2d_bn(branch5x5, 64, 5, 5, renorm=renorm,
-                          ghost_size=ghost_size, num_ghosts=num_ghosts)
+                          microbatch_size=microbatch_size,
+                          num_microbatches=num_microbatches)
 
     branch3x3dbl = conv2d_bn(x, 64, 1, 1, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
     branch3x3dbl = conv2d_bn(branch3x3dbl, 96, 3, 3, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
     branch3x3dbl = conv2d_bn(branch3x3dbl, 96, 3, 3, renorm=renorm,
-                             ghost_size=ghost_size, num_ghosts=num_ghosts)
+                             microbatch_size=microbatch_size,
+                             num_microbatches=num_microbatches)
 
     branch_pool = layers.AveragePooling2D((3, 3),
                                           strides=(1, 1),
                                           padding='same')(x)
     branch_pool = conv2d_bn(branch_pool, 64, 1, 1, renorm=renorm,
-                            ghost_size=ghost_size, num_ghosts=num_ghosts)
+                            microbatch_size=microbatch_size,
+                            num_microbatches=num_microbatches)
     x = layers.concatenate(
         [branch1x1, branch5x5, branch3x3dbl, branch_pool],
         axis=channel_axis,

--- a/main.py
+++ b/main.py
@@ -4,7 +4,10 @@ import tensorflow as tf
 from tensorflow import keras
 from tensorflow.keras.datasets.cifar10 import load_data
 
-BATCH_SIZE = 32  # As specified in paper
+# As specified in paper
+GHOST_SIZE = 32
+NUM_GHOSTS = 50
+BATCH_SIZE = GHOST_SIZE * NUM_GHOSTS
 NUM_EPOCHS = 1
 
 NUM_CLASSES = 10

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ from tensorflow.keras.datasets.cifar10 import load_data
 GHOST_SIZE = 32
 NUM_GHOSTS = 50
 BATCH_SIZE = GHOST_SIZE * NUM_GHOSTS
-NUM_EPOCHS = 1
+NUM_EPOCHS = 50
 
 NUM_CLASSES = 10
 HEIGHT = 32
@@ -31,6 +31,15 @@ class AccuracyHistory(keras.callbacks.Callback):
 (x_train, y_train), (x_test, y_test) = load_data()
 (x_val, y_val), (x_test, y_test) = \
             (x_test[:5000], y_test[:5000]), (x_test[5000:], y_test[5000:])
+
+# FIXME this is an ugly hack to make sure all data has a multiple of 1600 of
+# examples...
+x_train = x_train[:49600]
+y_train = y_train[:49600]
+x_val = x_val[:4800]
+y_val = y_val[:4800]
+x_test = x_test[:4800]
+y_test = y_test[:4800]
 
 # Normalize and reshape data and labels
 x_train, x_val, x_test = \

--- a/main.py
+++ b/main.py
@@ -5,10 +5,10 @@ from tensorflow import keras
 from tensorflow.keras.datasets.cifar10 import load_data
 
 # As specified in paper
-GHOST_SIZE = 32
-NUM_GHOSTS = 50
-BATCH_SIZE = GHOST_SIZE * NUM_GHOSTS
-NUM_EPOCHS = 50
+MICROBATCH_SIZE = 32
+NUM_MICROBATCHES = 50
+BATCH_SIZE = MICROBATCH_SIZE * NUM_MICROBATCHES
+NUM_EPOCHS = 1
 
 NUM_CLASSES = 10
 HEIGHT = 32
@@ -57,8 +57,8 @@ model = InceptionV3(
     pooling='avg',  # Global average pooling on output of the last conv layer
     classes=NUM_CLASSES,
     renorm=False,
-    ghost_size=GHOST_SIZE,
-    num_ghosts=NUM_GHOSTS
+    microbatch_size=MICROBATCH_SIZE,
+    num_microbatches=NUM_MICROBATCHES
 )
 
 model.compile(loss=keras.losses.categorical_crossentropy,

--- a/main.py
+++ b/main.py
@@ -46,7 +46,10 @@ model = InceptionV3(
     weights=None,  # Random initialization
     input_shape=[HEIGHT, WIDTH, NUM_CHANNELS],
     pooling='avg',  # Global average pooling on output of the last conv layer
-    classes=NUM_CLASSES
+    classes=NUM_CLASSES,
+    renorm=False,
+    ghost_size=GHOST_SIZE,
+    num_ghosts=NUM_GHOSTS
 )
 
 model.compile(loss=keras.losses.categorical_crossentropy,


### PR DESCRIPTION
The paper calls for batch norm (and renorm) to be applied to batches of 32, but the gradients must be averaged over 50 minibatches before updating parameters. We can achieve a similar effect using `tf.keras.layer.BatchNormalization`'s `virtual_batch_size` argument.